### PR TITLE
Added page for median absolute deviation

### DIFF
--- a/_aggregations/metric/median-absolute-deviation.md
+++ b/_aggregations/metric/median-absolute-deviation.md
@@ -3,7 +3,7 @@ layout: default
 title: Median Absolute Deviation
 parent: Metric aggregations
 grand_parent: Aggregations
-nav_order: 10
+nav_order: 65
 redirect_from:
   - /query-dsl/aggregations/metric/median-absolute-deviation/
 ---

--- a/_aggregations/metric/median-absolute-deviation.md
+++ b/_aggregations/metric/median-absolute-deviation.md
@@ -8,9 +8,9 @@ redirect_from:
   - /query-dsl/aggregations/metric/median-absolute-deviation/
 ---
 
-# Median Absolute Deviation aggregations
+# Median Absolute Deviation Aggregations
 
-The `median_absolute_deviation` metric is a single-value metric aggregation that returns median absolute deviation field. Median absolute deviation is a statistical measure of data variability. It is used to measure dispersion from the median, may be less impacted by outliers in a data set. 
+The `median_absolute_deviation` metric is a single-value metric aggregation that returns median absolute deviation field. Median absolute deviation is a statistical measure of data variability. It is used to measure dispersion from the median, may be less impacted by outliers in a dataset. 
 
 Median absolute deviation is calculated with:<br>
 median_absolute_deviation = median(|X<sub>i</sub> - Median(X<sub>i</sub>)|)
@@ -58,9 +58,7 @@ GET opensearch_dashboards_sample_data_flights/_search
       "value": 1829.8993624441966
     }
   }
-}}
-
-
+}
 ```
 
 ### Missing

--- a/_aggregations/metric/median-absolute-deviation.md
+++ b/_aggregations/metric/median-absolute-deviation.md
@@ -1,0 +1,112 @@
+---
+layout: default
+title: Median Absolute Deviation
+parent: Metric aggregations
+grand_parent: Aggregations
+nav_order: 10
+redirect_from:
+  - /query-dsl/aggregations/metric/median-absolute-deviation/
+---
+
+# Median Absolute Deviation aggregations
+
+The `median_absolute_deviation` metric is a single-value metric aggregation that returns median absolute deviation field. Median absolute deviation is a statistical measure of data variability. It is used to measure dispersion from the median, may be less impacted by outliers in a data set. 
+
+Median absolute deviation is calculated with:<br>
+median_absolute_deviation = median(|X<sub>i</sub> - Median(X<sub>i</sub>)|)
+
+The following example calculates the median absolute deviation of the `DistanceMiles` field of the opensearch_dashboards_sample_data_flights index:
+
+
+```json
+GET opensearch_dashboards_sample_data_flights/_search
+{
+  "size": 0,
+  "aggs": {
+    "median_absolute_deviation_DistanceMiles": {
+      "median_absolute_deviation": {
+        "field": "DistanceMiles"
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+#### Example response
+
+```json
+{
+  "took": 35,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "median_absolute_deviation_distanceMiles": {
+      "value": 1829.8993624441966
+    }
+  }
+}}
+
+
+```
+
+### Missing
+If there are documents in your index that are missing fields and you wish to set a default value for those documents, use the `missing` parameter to specify the default value for any missing fields from documents.
+
+```json
+GET opensearch_dashboards_sample_data_flights/_search
+{
+  "size": 0,
+  "aggs": {
+    "median_absolute_deviation_distanceMiles": {
+      "median_absolute_deviation": {
+        "field": "DistanceMiles",
+        "missing": 1000
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+#### Example response
+
+```json
+{
+  "took": 7,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "median_absolute_deviation_distanceMiles": {
+      "value": 1829.6443646143355
+    }
+  }
+}
+
+```

--- a/_aggregations/metric/median-absolute-deviation.md
+++ b/_aggregations/metric/median-absolute-deviation.md
@@ -15,7 +15,7 @@ The `median_absolute_deviation` metric is a single-value metric aggregation that
 Median absolute deviation is calculated with:<br>
 median_absolute_deviation = median(|X<sub>i</sub> - Median(X<sub>i</sub>)|)
 
-The following example calculates the median absolute deviation of the `DistanceMiles` field of the opensearch_dashboards_sample_data_flights index:
+The following example calculates the median absolute deviation of the `DistanceMiles` field of the opensearch_dashboards_sample_data_flights:
 
 
 ```json

--- a/_aggregations/metric/median-absolute-deviation.md
+++ b/_aggregations/metric/median-absolute-deviation.md
@@ -62,7 +62,7 @@ GET opensearch_dashboards_sample_data_flights/_search
 ```
 
 ### Missing
-If there are documents in your index that are missing fields and you wish to set a default value for those documents, use the `missing` parameter to specify the default value for any missing fields from documents.
+You can set a default value for missing fields from documents by specifying the `missing` parameter. This could be a missing field or a null value in a field.
 
 ```json
 GET opensearch_dashboards_sample_data_flights/_search


### PR DESCRIPTION
### Description
Adds a page for Median Absolute Deviation documentation

![image](https://github.com/Bit-Quill/documentation-website/assets/104795536/da637a62-9e96-4bde-bd6d-3ad805245d6d)
![image](https://github.com/Bit-Quill/documentation-website/assets/104795536/b46cd6c9-f69c-434d-aac0-44f9d0240d54)


### Issues Resolved
(Won't link for now)

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
